### PR TITLE
Handle INT_MAX and INT_MIN in free

### DIFF
--- a/push_swap.h
+++ b/push_swap.h
@@ -18,7 +18,7 @@
 # include <stdbool.h>
 # include "libft/libft.h"
 
-# define ATOI_ERROR -1
+
 
 typedef struct s_stack
 {
@@ -31,7 +31,8 @@ typedef struct s_stack
 //main
 int		add_to_stack(t_stack *a, char *word);
 void	init_stack(t_stack *a, t_stack *b, int size);
-void	read_arg(int argc, char **argv, t_stack *a);
+void	read_arg(int argc, char **argv, t_stack *a, t_stack *b);
+void	process_split_words(char **nbs, t_stack *a, t_stack *b);
 void	err_exit(void);
 
 //ope

--- a/push_swap.h
+++ b/push_swap.h
@@ -18,7 +18,7 @@
 # include <stdbool.h>
 # include "libft/libft.h"
 
-# define ATOI_ERROR 0
+# define ATOI_ERROR -1
 
 typedef struct s_stack
 {

--- a/push_swap.h
+++ b/push_swap.h
@@ -18,6 +18,8 @@
 # include <stdbool.h>
 # include "libft/libft.h"
 
+# define ATOI_ERROR 0
+
 typedef struct s_stack
 {
 	int	*stack;
@@ -63,7 +65,7 @@ void	set_both_rotate(t_stack *a, t_stack *b, int b_nb, int a_nb);
 
 //utils
 bool	is_digit_str(char *str);
-int		ps_atoi(const char *str);
+long	ps_atoi(const char *str);
 int		count_word(char **argv);
 void	all_free(char **result);
 bool	is_unique(t_stack *a);

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,7 @@ int	main(int argc, char **argv)
 	if (argc <= 1)
 		return (0);
 	init_stack(&a, &b, count_word(argv));
-	read_arg(argc, argv, &a);
+	read_arg(argc, argv, &a, &b);
 	if (is_sorted(&a))
 	{
 		free(a.stack);
@@ -55,7 +55,7 @@ void	init_stack(t_stack *a, t_stack *b, int size)
 	b->min = INT_MAX;
 }
 
-void	read_arg(int argc, char **argv, t_stack *a)
+void	read_arg(int argc, char **argv, t_stack *a, t_stack *b)
 {
 	int		i;
 	int		index;
@@ -67,12 +67,18 @@ void	read_arg(int argc, char **argv, t_stack *a)
 		index = 0;
 		nbs = ft_split(argv[i], ' ');
 		if (!nbs)
+		{
+			free(a->stack);
+			free(b->stack);
 			err_exit();
+		}
 		while (nbs[index])
 		{
 			if (add_to_stack(a, nbs[index]) == -1)
 			{
 				all_free(nbs);
+				free(a->stack);
+				free(b->stack);
 				err_exit();
 			}
 			index++;

--- a/src/main.c
+++ b/src/main.c
@@ -85,9 +85,14 @@ void	read_arg(int argc, char **argv, t_stack *a)
 
 int	add_to_stack(t_stack *a, char *word)
 {
+	long	value;
+
 	if (!is_digit_str(word))
 		return (-1);
-	a->stack[a->size] = ps_atoi(word);
+	value = ps_atoi(word);
+	if (value == LONG_MAX)
+		return (-1);
+	a->stack[a->size] = (int)value;
 	if (!is_unique(a))
 		return (-1);
 	if (a->max < a->stack[a->size])

--- a/src/main.c
+++ b/src/main.c
@@ -55,16 +55,33 @@ void	init_stack(t_stack *a, t_stack *b, int size)
 	b->min = INT_MAX;
 }
 
+void	process_split_words(char **nbs, t_stack *a, t_stack *b)
+{
+	int	index;
+
+	index = 0;
+	while (nbs[index])
+	{
+		if (add_to_stack(a, nbs[index]) == -1)
+		{
+			all_free(nbs);
+			free(a->stack);
+			free(b->stack);
+			err_exit();
+		}
+		index++;
+		a->size++;
+	}
+}
+
 void	read_arg(int argc, char **argv, t_stack *a, t_stack *b)
 {
 	int		i;
-	int		index;
 	char	**nbs;
 
 	i = 1;
 	while (i < argc)
 	{
-		index = 0;
 		nbs = ft_split(argv[i], ' ');
 		if (!nbs)
 		{
@@ -72,18 +89,7 @@ void	read_arg(int argc, char **argv, t_stack *a, t_stack *b)
 			free(b->stack);
 			err_exit();
 		}
-		while (nbs[index])
-		{
-			if (add_to_stack(a, nbs[index]) == -1)
-			{
-				all_free(nbs);
-				free(a->stack);
-				free(b->stack);
-				err_exit();
-			}
-			index++;
-			a->size++;
-		}
+		process_split_words(nbs, a, b);
 		all_free(nbs);
 		i++;
 	}

--- a/src/utils.c
+++ b/src/utils.c
@@ -11,7 +11,6 @@
 /* ************************************************************************** */
 
 #include "../push_swap.h"
-#include <errno.h>
 
 long	ps_atoi(const char *str)
 {
@@ -20,18 +19,16 @@ long	ps_atoi(const char *str)
 
 	sign = 1;
 	value = 0;
-	if (*str == '-')
-		sign = -1;
 	if (*str == '-' || *str == '+')
 		str++;
+	if (*str == '-')
+		sign = -1;
 	while (*str)
 	{
 		value = value * 10 + *str - '0';
 		if ((sign == 1 && value > INT_MAX)
 			|| (sign == -1 && value > (long)INT_MAX + 1))
-		{
 			return (LONG_MAX);
-		}
 		str++;
 	}
 	return (value * sign);

--- a/src/utils.c
+++ b/src/utils.c
@@ -28,8 +28,10 @@ long	ps_atoi(const char *str)
 	{
 		value = value * 10 + *str - '0';
 		if ((sign == 1 && value > INT_MAX)
-			|| (sign == -1 && value - 1 > INT_MAX))
+			|| (sign == -1 && value > (long)INT_MAX + 1))
+		{
 			return (LONG_MAX);
+		}
 		str++;
 	}
 	return (value * sign);

--- a/src/utils.c
+++ b/src/utils.c
@@ -11,8 +11,9 @@
 /* ************************************************************************** */
 
 #include "../push_swap.h"
+#include <errno.h>
 
-int	ps_atoi(const char *str)
+long	ps_atoi(const char *str)
 {
 	long	value;
 	int		sign;
@@ -28,10 +29,10 @@ int	ps_atoi(const char *str)
 		value = value * 10 + *str - '0';
 		if ((sign == 1 && value > INT_MAX)
 			|| (sign == -1 && value - 1 > INT_MAX))
-			err_exit();
+			return (LONG_MAX);
 		str++;
 	}
-	return ((int)(value * sign));
+	return (value * sign);
 }
 
 bool	is_digit_str(char *str)


### PR DESCRIPTION
Refactor `ps_atoi` to return `long` and signal integer overflow with `LONG_MAX`, enabling proper memory cleanup before program exit.

---
<a href="https://cursor.com/background-agent?bcId=bc-959fe9de-a32d-4d53-af32-cbd446d79f8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-959fe9de-a32d-4d53-af32-cbd446d79f8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

